### PR TITLE
Fix and improve docstring documentation

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,10 @@
 
 <!-- Here goes the main new features and examples or instructions on how to use them -->
 
+## Enhancements
+
+- Improved the docstring documentation of the project.
+
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+- Fixed typos and a broken admonition in docstrings.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,6 +114,7 @@ plugins:
             show_source: true
             show_symbol_type_toc: true
             signature_crossrefs: true
+            relative_crossrefs: true
           inventories:
             # See https://mkdocstrings.github.io/python/usage/#import for details
             - https://docs.python.org/3/objects.inv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,9 @@ arg-type-hints-in-docstring = false
 arg-type-hints-in-signature = true
 allow-init-docstring = true
 count = true
+check-class-attributes = true
+check-style-mismatch = true
+require-inline-class-var-docs = true
 
 [tool.pylint.similarities]
 ignore-comments = ['yes']

--- a/src/flake8_numbers/check_numbers.py
+++ b/src/flake8_numbers/check_numbers.py
@@ -65,7 +65,7 @@ def _separator_modulo_for_base(base: int) -> int:
 
 
 class Flake8NumbersChecker:
-    """class to represent a flake8 plugin to check for numbers and their readability."""
+    """A flake8 plugin to check for numbers and their readability."""
 
     name = "flake8.numbers"
     version = metadata.version("flake8-numbers")
@@ -87,12 +87,9 @@ class Flake8NumbersChecker:
 
     @property
     def source_lines(self) -> list[str]:
-        """Get the source lines of the file being checked.
+        """The source lines of the file being checked.
 
         This value is cached on-demand.
-
-        Returns:
-            The source lines of the file being checked.
         """
         if self._source_lines is None:
             with open(self._filename, "r", encoding="utf-8") as source_file:

--- a/src/flake8_numbers/check_numbers.py
+++ b/src/flake8_numbers/check_numbers.py
@@ -42,9 +42,10 @@ def _base_value(number_literal: str) -> int:
 def _separator_modulo_for_base(base: int) -> int:
     """Get the separator modulo for the given base.
 
-    Note: We keep this currently as helper function, to make that part of the code
-    more readable as well as open up the possibility of making this configurable
-    in the future.
+    Note:
+        We keep this currently as a helper function, to make that part of the
+        code more readable as well as open up the possibility of making this
+        configurable in the future.
 
     Args:
         base: The base to get the separator modulo for.

--- a/src/flake8_numbers/check_numbers.py
+++ b/src/flake8_numbers/check_numbers.py
@@ -140,7 +140,7 @@ class Flake8NumbersChecker:
     ) -> Optional[ErrorReport]:
         """Check the given fragment for underscores at every modulo position.
 
-        Every part of the fragemnt that is separated by an underscore must be of length modulo.
+        Every part of the fragment that is separated by an underscore must be of length modulo.
         The first part of the fragment is allowed to be shorter than modulo.
 
         Args:


### PR DESCRIPTION
🤖 This pull request is part of an automated effort to improve the docstring documentation of all our projects.

Main issues being resolved:
- Typos in docstrings
- Broken `Note:` admonition that placed its whole body on the header line
- Class docstring summary missing the leading capital letter and "A" article
- Property docstring using imperative mood instead of a noun phrase

Other things to note:
- The `relative_crossrefs: true` mkdocstrings option was added to `mkdocs.yml` as part of the rolling-out of relative cross-reference conventions.
- Three new pydoclint options were added to `pyproject.toml` (`check-class-attributes`, `check-style-mismatch`, `require-inline-class-var-docs`) as part of the rolling-out of stricter docstring checks.
- The redundant `Returns:` section on the `source_lines` property was dropped, since properties are documented like attributes.